### PR TITLE
Updated old `ContravariantLifetime<'a>` to `PhantomData<&'a ()>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "nullable"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 repository = "https://github.com/reem/rust-nullable.git"
 description = "A wrapper around raw pointers with lifetime tracking."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,10 @@
-//#![deny(missing_docs, warnings)]
-
 //! Nullable, lifetime-tracked pointers.
 
-use std::kinds::marker;
+use std::marker;
 use std::mem;
 
 pub struct Nullable<'a, T: 'a> {
-    lifetime: marker::ContravariantLifetime<'a>,
+    lifetime: marker::PhantomData<&'a ()>,
     data: *const T
 }
 
@@ -16,7 +14,7 @@ unsafe impl<'a, T: Sync> Sync for Nullable<'a, T> {}
 impl<'a, T> Nullable<'a, T> {
     pub unsafe fn new(t: *const T) -> Nullable<'a, T> {
         Nullable {
-            lifetime: marker::ContravariantLifetime,
+            lifetime: marker::PhantomData,
             data: t
         }
     }
@@ -31,14 +29,14 @@ impl<'a, T> Nullable<'a, T> {
 }
 
 pub struct NullableMut<'a, T: 'a> {
-    lifetime: marker::ContravariantLifetime<'a>,
+    lifetime: marker::PhantomData<&'a ()>,
     data: *mut T
 }
 
 impl<'a, T> NullableMut<'a, T> {
     pub unsafe fn new(t: *mut T) -> NullableMut<'a, T> {
         NullableMut {
-            lifetime: marker::ContravariantLifetime,
+            lifetime: marker::PhantomData,
             data: t
         }
     }


### PR DESCRIPTION
See: https://www.cs.brandeis.edu/~cs146a/rust/doc-02-21-2015/src/core/marker.rs.html#396

I have no experience with raw pointer safety in Rust (in fact that is what led me to find this crate) so I don't know if this is still safe or useful.